### PR TITLE
Notification

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/NotificationReadRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/NotificationReadRequest.swift
@@ -1,0 +1,34 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct NotificationReadRequest: RestAPIRequest {
+    typealias RequestBody = Void
+    typealias Response = NotificationReadResponse
+    
+    let method: HTTPMethod = .get
+    
+    let queryParameters: [String: Any]?
+    
+    init(notificationId: Int, wsToken: String) {
+        queryParameters = [
+            "moodlewsrestformat" : "json",
+            "wstoken" : wsToken,
+            "notificationid" : notificationId,
+            "wsfunction" : "core_message_mark_notification_read"
+        ]
+    }
+}
+
+public struct NotificationReadResponse: Codable {
+    public let notificationid: Int
+    public let warnings: [NotificationReadResponseWarning]
+}
+
+public struct NotificationReadResponseWarning: Codable {
+    public let item: String
+    public let itemid: Int
+    public let warningcode: String
+    public let message: String
+}

--- a/Sources/T2ScholaCoreSwift/Request/PopupNotificationRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/PopupNotificationRequest.swift
@@ -1,0 +1,36 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct PopupNotificationRequest: RestAPIRequest {
+    typealias RequestBody = Void
+    typealias Response = PopupNotificationResponse
+    
+    let method: HTTPMethod = .get
+    
+    let queryParameters: [String: Any]?
+    
+    init(wsToken: String, userId: Int) {
+        queryParameters = [
+            "moodlewsrestformat" : "json",
+            "wstoken" : wsToken,
+            "useridto" : userId,
+            "wsfunction" : "message_popup_get_popup_notifications"
+        ]
+    }
+}
+
+public struct PopupNotificationResponse: Codable {
+    public let unreadcount: Int
+    public let notifications: [PopupNotification]
+}
+
+public struct PopupNotification: Codable {
+    public let subject: String
+    public let fullmessage: String
+    public let timecreated: Int
+    public let read: Bool
+    public let contexturl: String
+}
+

--- a/Sources/T2ScholaCoreSwift/Request/PopupNotificationRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/PopupNotificationRequest.swift
@@ -11,7 +11,7 @@ struct PopupNotificationRequest: RestAPIRequest {
     
     let queryParameters: [String: Any]?
     
-    init(wsToken: String, userId: Int) {
+    init(userId: Int, wsToken: String) {
         queryParameters = [
             "moodlewsrestformat" : "json",
             "wstoken" : wsToken,

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -47,7 +47,11 @@ public struct T2Schola {
     }
     
     public func getPopupNotification(userId: Int, wsToken: String) async throws -> PopupNotificationResponse {
-        try await apiClient.send(request: PopupNotificationRequest(wsToken: wsToken, userId: userId))
+        try await apiClient.send(request: PopupNotificationRequest(userId: userId, wsToken: wsToken))
+    }
+    
+    public func markNotificationRead(notificationId: Int, wsToken: String) async throws -> NotificationReadResponse {
+        try await apiClient.send(request: NotificationReadRequest(notificationId: notificationId, wsToken: wsToken))
     }
     
     public static func changeToMock() {

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -46,6 +46,10 @@ public struct T2Schola {
         try await apiClient.send(request: UpdateActivityCompletionStatusManuallyRequest(moduleId: moduleId, completed: completed, wsToken: wsToken))
     }
     
+    public func getPopupNotification(userId: Int, wsToken: String) async throws -> PopupNotificationResponse {
+        try await apiClient.send(request: PopupNotificationRequest(wsToken: wsToken, userId: userId))
+    }
+    
     public static func changeToMock() {
         changeToMockBaseHost()
     }

--- a/Sources/T2ScholaCoreSwiftRun/main.swift
+++ b/Sources/T2ScholaCoreSwiftRun/main.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by nanashiki on 2020/12/13.
 //
@@ -14,9 +14,10 @@ enum RunType {
     case login
     case courseContents
     case assignments
+    case notifications
 }
 
-let runType: RunType = .login
+let runType: RunType = .notifications
 
 let t2Schola =  T2Schola()
 // T2Schola.changeToMock()
@@ -93,9 +94,24 @@ case .assignments:
             exit(1)
         }
     }
+case .notifications:
+    print("Please input your wsToken: ", terminator:"")
+    let wsToken = readLine()!
+    
+    Task {
+        do {
+            let info = try await t2Schola.getSiteInfo(wsToken: wsToken)
+            let notifications = try await t2Schola.getPopupNotification(userId: info.userid, wsToken: wsToken)
+            print("unread notification count: \(notifications.unreadcount)")
+            for message in notifications.notifications {
+                print(message.read ? "[read] \(message.subject)" : "[unread] \(message.subject)")
+            }
+            exit(0)
+        } catch {
+            print("error \(error)")
+            exit(1)
+        }
+    }
 }
 
 RunLoop.current.run()
-
-
-

--- a/Sources/T2ScholaCoreSwiftRun/main.swift
+++ b/Sources/T2ScholaCoreSwiftRun/main.swift
@@ -14,12 +14,13 @@ enum RunType {
     case login
     case courseContents
     case assignments
-    case notifications
+    case getNotifications
+    case markNotificationAsRead
 }
 
-let runType: RunType = .notifications
+let runType: RunType = .markNotificationAsRead
 
-let t2Schola =  T2Schola()
+let t2Schola = T2Schola()
 // T2Schola.changeToMock()
 
 switch runType {
@@ -94,7 +95,7 @@ case .assignments:
             exit(1)
         }
     }
-case .notifications:
+case .getNotifications:
     print("Please input your wsToken: ", terminator:"")
     let wsToken = readLine()!
     
@@ -112,6 +113,25 @@ case .notifications:
             exit(1)
         }
     }
+case .markNotificationAsRead:
+    print("Please input your wsToken: ", terminator:"")
+    let wsToken = readLine()!
+    print("Please input notification id to mark as read: ", terminator:"")
+    let notificationId = Int(readLine()!)!
+    
+    Task {
+        do {
+            let response = try await t2Schola.markNotificationRead(notificationId: notificationId, wsToken: wsToken)
+            if (response.warnings.count == 0) {
+                print("Successfully marked")
+            }
+            exit(0)
+        } catch {
+            print("error \(error)")
+            exit(1)
+        }
+    }
 }
+
 
 RunLoop.current.run()


### PR DESCRIPTION
- getPopupNotification
    - userIdとwsTokenから、学生の通知一覧・未読通知数を取得する
    - `message_popup_get_popup_notifications`を使用
    - 各通知のうち得るのは現状 subject, fullmessage, timecreated, read, contexturl の5つ。fullmessageやtimecreatedは不要の可能性あり
    - 未読通知数は別に単体で得る関数があるので、未読通知の有無での表示マークの変更なら毎回全通知を得るよりも単独で得る方が良いかも
- markNotificationRead
    - notificationIdとwsTokenから、当該の通知を既読にマークする
    - `core_message_mark_notification_read`を使用
    - レスポンスの`NotificationReadResponseWarning`は要るかどうか分からなかった
 