### PR TITLE
提出コメントの取得

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/SubmissionCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/SubmissionCommentsRequest.swift
@@ -1,0 +1,59 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct SubmissionCommentsRequest: RestAPIRequest {
+    typealias RequestBody = Void
+    typealias Response = SubmissionCommentsResponse
+    
+    let method: HTTPMethod = .get
+    
+    let queryParameters: [String: Any]?
+    
+    init(instanceId: Int, itemId: Int, wsToken: String) {
+        queryParameters = [
+            "moodlewsrestformat" : "json",
+            "wstoken" : wsToken,
+            "contextlevel" : "module",
+            "instanceid" : instanceId,
+            "component" : "assignsubmission_comments",
+            "itemid" : itemId,
+            "area" : "submission_comments",
+            "wsfunction" : "core_comment_get_comments"
+        ]
+    }
+}
+
+public struct SubmissionCommentsResponse: Codable {
+    public let comments: [SubmissionCommentResponse] //List of comments
+    public let count: Int?  //Total number of comments.
+    public let perpage: Int?  //Number of comments per page.
+    public let canpost: Bool?  //Whether the user can post in this comment area.
+    public let warnings: [SubmissionCommentsResponseWarning]?  //list of warnings
+}
+
+
+public struct SubmissionCommentResponse: Codable {
+    public let id: Int   //Comment ID
+    public let content: String   //The content text formatted
+    public let format: Int   //content format (1 = HTML, 0 = MOODLE, 2 = PLAIN or 4 = MARKDOWN)
+    public let timecreated: Int   //Time created (timestamp)
+    public let strftimeformat: String   //Time format
+    public let profileurl: String   //URL profile
+    public let fullname: String   //fullname
+    public let time: String   //Time in human format
+    public let avatar: String   //HTML user picture
+    public let userid: Int   //User ID
+    public let delete: Bool?  //Permission to delete=true/false
+}
+
+public struct SubmissionCommentsResponseWarning: Codable {
+    public let item: String?
+    public let itemid: Int?
+    // The warning code can be used by the client app to implement specific behaviour.
+    public let warningcode: String
+    // Untranslated english message to explain the warning.
+    public let message: String
+}
+

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -58,6 +58,10 @@ public struct T2Schola {
         try await apiClient.send(request: NotificationReadRequest(notificationId: notificationId, wsToken: wsToken))
     }
     
+    public func getSubmissionComments(instanceId: Int, itemId: Int, wsToken: String) async throws -> SubmissionCommentsResponse {
+        try await apiClient.send(request: SubmissionCommentsRequest(instanceId: instanceId, itemId: itemId, wsToken: wsToken))
+    }
+
     public static func changeToMock() {
         changeToMockBaseHost()
     }


### PR DESCRIPTION
関数`core_comment_get_comments`を用いて、提出コメントを取得する機能を追加しました
- 引数
    - `wstoken`
    - `instanceId`：課題の特定
    - `itemId`：提出物の特定
- 戻り値
    - コメント情報の配列