### PR TITLE
ファイルをアップロードする機能の作成

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/Protocol/UploadAPIRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/Protocol/UploadAPIRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol UploadAPIRequest: T2ScholaRequest {}
+
+extension UploadAPIRequest {
+    var path: String {
+        "webservice/upload.php"
+    }
+}

--- a/Sources/T2ScholaCoreSwift/Request/UploadFileRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/UploadFileRequest.swift
@@ -1,0 +1,44 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct UploadFileRequest: UploadAPIRequest {
+    typealias RequestBody = MultipartFormDatasBody
+    typealias Response = UploadFilesResponse
+    
+    let method: HTTPMethod = .post
+    
+    var requestBody: MultipartFormDatasBody = []
+    
+    init(file: Data, mimeType: String, fileName: String, wsToken: String) {
+        let fileBody = UploadFileRequestBody(data: file, name: "upfile", mimeType: mimeType, fileName: fileName)
+        let tokenBody = UploadFileRequestBody(data: (wsToken.data(using: .utf8) ?? "".data(using: .utf8))!, name: "token", mimeType: "", fileName: "")
+        requestBody.append(tokenBody)
+        requestBody.append(fileBody)
+    }
+}
+
+public struct UploadFileRequestBody: MultipartFormDataBody {
+    public let data: Data
+    public let name: String
+    public let mimeType: String
+    public let fileName: String
+}
+
+public typealias UploadFilesResponse = [UploadFileResponse]
+
+public struct UploadFileResponse: Codable {
+    public let component: String
+    public let contextid: Int
+    public let userid: String
+    public let filearea: String
+    public let filename: String
+    public let filepath: String
+    public let itemid: Int
+    public let license: String? // File license.
+    public let author: String? // File owner.
+    public let source: String
+    public let timecreated: Int? // Time created.
+    public let filesize: Int? // File size.
+}

--- a/Sources/T2ScholaCoreSwift/Request/UploadFileRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/UploadFileRequest.swift
@@ -9,13 +9,15 @@ struct UploadFileRequest: UploadAPIRequest {
     
     let method: HTTPMethod = .post
     
-    var requestBody: MultipartFormDatasBody = []
+    let requestBody: MultipartFormDatasBody
     
     init(file: Data, mimeType: String, fileName: String, wsToken: String) {
+        var requestBody: MultipartFormDatasBody = []
         let fileBody = UploadFileRequestBody(data: file, name: "upfile", mimeType: mimeType, fileName: fileName)
         let tokenBody = UploadFileRequestBody(data: (wsToken.data(using: .utf8) ?? "".data(using: .utf8))!, name: "token", mimeType: "", fileName: "")
         requestBody.append(tokenBody)
         requestBody.append(fileBody)
+        self.requestBody = requestBody
     }
 }
 

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -58,6 +58,10 @@ public struct T2Schola {
         try await apiClient.send(request: NotificationReadRequest(notificationId: notificationId, wsToken: wsToken))
     }
     
+    public func uploadFile(file: Data, fileType: String, mimeType: String, fileName: String, wsToken: String) async throws -> UploadFilesResponse {
+        try await apiClient.send(request: UploadFileRequest(file: file, mimeType: mimeType, fileName: fileName, wsToken: wsToken))
+    }
+    
     public static func changeToMock() {
         changeToMockBaseHost()
     }


### PR DESCRIPTION
ファイル提出を行う際に必要となる、ローカルからドラフトへのファイルのアップロード機能を追加しました。
- Request時にmultipart/form-dataで複数の項目をPOSTできるよう修正
- webservice/upload.phpへrequestできるUploadAPIRequest.swiftの追加
- 1ファイルをアップロードできる関数の追加
    - 引数
         - `file`：送信ファイル
         - `mimeType`
         - `fileName`
         - `wsToken`
     - 戻り値
         - ファイル情報の配列

得られた`itemid`を用いることで後の提出が可能になる仕組み。
現在は1ファイルの送信のみに対応しています。ネイティブ化には不要とのことなので一旦保留しておきます