### PR TITLE
課題詳細リクエストの修正

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
@@ -99,7 +99,7 @@ public struct AssignmentSubmission: Codable {
     public let timecreated: Date // Submission creation time.
     public let timemodified: Date // Submission last modified time.
     public let status: AssignmentSubmissionStatus // Submission status.
-    public let groupid: Int // Group id.
+    public let groupid: Int? // Group id.
     public let assignment: Int? // Assignment id.
     public let latest: Int? // Latest attempt.
     public let plugins: [AddonModAssignPlugin]?; // Plugins.

--- a/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
@@ -23,12 +23,43 @@ struct AssignmentSubmissionStatusRequest: RestAPIRequest {
 }
 
 public struct AssignmentSubmissionStatusResponse: Codable {
-    //public let gradingsummary: AssignmentSubmissionGradingSummary? // Grading information.
+    public let gradingsummary: [AssignmentSubmissionGradingSummary]? // Grading information.
     public let lastattempt: AssignmentSubmissionLastAttempt? // Last attempt information.
     public let feedback: AssignmentSubmissionFeedback?; // Feedback for the last attempt.
     public let previousattempts: [AssignmentSubmissionPreviousAttempt]? // List all the previous attempts did by the user.
-    // public let warnings?: CoreWSExternalWarning[];
+    public let assignmentdata: AssignmentSubmissionStatusData? // @since 4.0. Extra information about assignment.
+    public let warnings: [AssignmentSubmissionStatusResponseWarning]?
 }
+
+public struct AssignmentSubmissionGradingSummary: Codable {
+    public let participantcount: Int // Number of users who can submit.
+    public let submissiondraftscount: Int // Number of submissions in draft status.
+    public let submissionsenabled: Bool // Whether submissions are enabled or not.
+    public let submissionssubmittedcount: Int // Number of submissions in submitted status.
+    public let submissionsneedgradingcount: Int // Number of submissions that need grading.
+    // warnofungroupedusers: string | boolean; // Whether we need to warn people about groups.
+}
+
+public struct AssignmentSubmissionStatusData: Codable {
+    public let attachments: AssignmentSubmissionStatusDataAttachments? // Intro and activity attachments.
+    public let activity: String? // Text of activity.
+    public let activityformat: Int? // Format of activity.
+}
+
+public struct AssignmentSubmissionStatusDataAttachments: Codable {
+    public let intro: [CoreWSExternalFile]? // Intro attachments files.
+    public let activity: [CoreWSExternalFile]? // Activity attachments files.
+}
+
+public struct AssignmentSubmissionStatusResponseWarning: Codable {
+    public let item: String?
+    public let itemid: Int?
+    // The warning code can be used by the client app to implement specific behaviour.
+    public let warningcode: String
+    // Untranslated english message to explain the warning.
+    public let message: String
+}
+
 
 public struct AssignmentSubmissionLastAttempt: Codable {
     public let submission: AssignmentSubmission? // Submission info.
@@ -39,7 +70,7 @@ public struct AssignmentSubmissionFeedback: Codable {
     public let grade: AssignmentSubmissionGrade? // Grade information.
     public let gradefordisplay: String? // Grade rendered into a format suitable for display.
     public let gradeddate: Date? // The date the user was graded.
-//    public let plugins: [AddonModAssignPlugin]? // Plugins info.
+    public let plugins: [AddonModAssignPlugin]? // Plugins info.
 }
 
 public struct AssignmentSubmissionGrade: Codable {
@@ -58,7 +89,7 @@ public struct AssignmentSubmissionPreviousAttempt: Codable {
     public let attemptnumber: Int // Attempt number.
     public let submission: AssignmentSubmission? // Submission info.
     public let grade: AssignmentSubmissionGrade? // Grade information.
-//    public let feedbackplugins: [AddonModAssignPlugin]? // Feedback info.
+    public let feedbackplugins: [AddonModAssignPlugin]? // Feedback info.
 }
 
 public struct AssignmentSubmission: Codable {
@@ -68,12 +99,34 @@ public struct AssignmentSubmission: Codable {
     public let timecreated: Date // Submission creation time.
     public let timemodified: Date // Submission last modified time.
     public let status: AssignmentSubmissionStatus // Submission status.
-//    public let groupid: Int // Group id.
-//    public let assignment: Int? // Assignment id.
-//    public let latest: Int? // Latest attempt.
-//    public let plugins: [AddonModAssignPlugin]?; // Plugins.
-//    public let gradingstatus: String? // @since 3.2. Grading status.
+    public let groupid: Int // Group id.
+    public let assignment: Int? // Assignment id.
+    public let latest: Int? // Latest attempt.
+    public let plugins: [AddonModAssignPlugin]?; // Plugins.
+    public let gradingstatus: String? // @since 3.2. Grading status.
+    public let timestarted: Int? // @since 4.0. Submission start time.
 }
+
+public struct AddonModAssignPlugin: Codable {
+    public let type: String // Submission plugin type.
+    public let name: String // Submission plugin name.
+    public let fileareas: [AddonModAssignPluginFilearea]? // Fileareas.
+    public let editorfields: [AddonModAssignPluginEditorfield]? // Editorfields.
+    
+}
+
+public struct AddonModAssignPluginFilearea: Codable {
+    public let area: String // File area.
+    public let files: [CoreWSExternalFile]?
+}
+
+public struct AddonModAssignPluginEditorfield: Codable {
+    public let name: String // Field name.
+    public let description: String // Field description.
+    public let text: String // Field value.
+    public let format: Int // Text format (1 = HTML, 0 = MOODLE, 2 = PLAIN or 4 = MARKDOWN).
+}
+    
 
 public enum AssignmentSubmissionStatus: String, Codable {
     case new = "new"


### PR DESCRIPTION
- `AssignmentSubmissionStatusRequest.swift`の修正
    - `AddonModAssignPlugin`を追加。これにより、提出ファイル/オンラインテキストや、フィードバックのファイル/オンラインテキストの取得が可能になる
    - その他、未実装だったパラメータも追加
    - 型の決定には[moodleapp/assign.ts](https://github.com/moodlehq/moodleapp/blob/master/src/addons/mod/assign/services/assign.ts)を参考にした
    - 私の課題データでのparseの検証は行えた

なお、 `warnofungroupedusers: string | boolean;` と戻り値の型が一意でないもののみparseしていない