### PR TITLE
提出コメントの追加・削除

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/AddCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AddCommentsRequest.swift
@@ -32,7 +32,7 @@ struct AddCommentsRequest: RestAPIRequest {
     }
 }
 
-public struct AddCommentsRequestBody: UrlEncodedBody {
+public struct AddCommentsRequestBody: WwwFormUrlEncodedBody {
     public let query: [String : Any]
 }
 

--- a/Sources/T2ScholaCoreSwift/Request/AddCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AddCommentsRequest.swift
@@ -7,7 +7,7 @@ struct AddCommentsRequest: RestAPIRequest {
     typealias RequestBody = Void
     typealias Response = AddCommentsResponse
     
-    let method: HTTPMethod = .get
+    let method: HTTPMethod = .post
     
     let queryParameters: [String: Any]?
     

--- a/Sources/T2ScholaCoreSwift/Request/AddCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AddCommentsRequest.swift
@@ -4,15 +4,20 @@ import FoundationNetworking
 #endif
 
 struct AddCommentsRequest: RestAPIRequest {
-    typealias RequestBody = Void
+    typealias RequestBody = AddCommentsRequestBody
     typealias Response = AddCommentsResponse
     
     let method: HTTPMethod = .post
     
+    var requestBody: RequestBody
     let queryParameters: [String: Any]?
     
     init(instanceId: Int, itemId: Int, comment: String, wsToken: String) {
         queryParameters = [
+            "moodlewsrestformat" : "json",
+            "wsfunction" : "core_comment_add_comments",
+        ]
+        let query: [String: Any] = [
             "moodlewsrestformat" : "json",
             "wstoken" : wsToken,
             "wsfunction" : "core_comment_add_comments",
@@ -23,7 +28,12 @@ struct AddCommentsRequest: RestAPIRequest {
             "comments[0][area]" : "submission_comments", //string comment area (default: "")
             "comments[0][content]" : comment //component
         ]
+        self.requestBody = AddCommentsRequestBody(query: query)
     }
+}
+
+public struct AddCommentsRequestBody: UrlEncodedBody {
+    public let query: [String : Any]
 }
 
 public typealias AddCommentsResponse = [AddCommentResponse]

--- a/Sources/T2ScholaCoreSwift/Request/AddCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AddCommentsRequest.swift
@@ -1,0 +1,43 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct AddCommentsRequest: RestAPIRequest {
+    typealias RequestBody = Void
+    typealias Response = AddCommentsResponse
+    
+    let method: HTTPMethod = .get
+    
+    let queryParameters: [String: Any]?
+    
+    init(instanceId: Int, itemId: Int, comment: String, wsToken: String) {
+        queryParameters = [
+            "moodlewsrestformat" : "json",
+            "wstoken" : wsToken,
+            "wsfunction" : "core_comment_add_comments",
+            "comments[0][contextlevel]" : "module", //contextlevel system, course, user...
+            "comments[0][instanceid]" : instanceId, //the id of item associated with the contextlevel
+            "comments[0][component]" : "assignsubmission_comments", //component
+            "comments[0][itemid]" : itemId, //associated id
+            "comments[0][area]" : "submission_comments", //string comment area (default: "")
+            "comments[0][content]" : comment //component
+        ]
+    }
+}
+
+public typealias AddCommentsResponse = [AddCommentResponse]
+
+public struct AddCommentResponse: Codable {
+    public let id: Int   //Comment ID
+    public let content: String   //The content text formatted
+    public let format: Int   //content format (1 = HTML, 0 = MOODLE, 2 = PLAIN or 4 = MARKDOWN)
+    public let timecreated: Int   //Time created (timestamp)
+    public let strftimeformat: String   //Time format
+    public let profileurl: String   //URL profile
+    public let fullname: String   //fullname
+    public let time: String   //Time in human format
+    public let avatar: String   //HTML user picture
+    public let userid: Int   //User ID
+    public let delete: Bool?   //Permission to delete=true/false
+}

--- a/Sources/T2ScholaCoreSwift/Request/DeleteCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/DeleteCommentsRequest.swift
@@ -4,21 +4,29 @@ import FoundationNetworking
 #endif
 
 struct DeleteCommentsRequest: RestAPIRequest {
-    typealias RequestBody = Void
+    typealias RequestBody = DeleteCommentsRequestBody
     typealias Response = DeleteCommentsResponse
     
     let method: HTTPMethod = .post
     
+    var requestBody: RequestBody
     let queryParameters: [String: Any]?
     
     init(commentId: Int, wsToken: String) {
         queryParameters = [
             "moodlewsrestformat" : "json",
+            "wsfunction" : "core_comment_delete_comments"
+        ]
+        let query: [String: Any] = [
             "wstoken" : wsToken,
-            "wsfunction" : "core_comment_delete_comments",
             "comments[0]" : commentId //id of the comment (default: 0)
         ]
+        self.requestBody = DeleteCommentsRequestBody(query: query)
     }
+}
+
+public struct DeleteCommentsRequestBody: UrlEncodedBody {
+    public let query: [String : Any]
 }
 
 public typealias DeleteCommentsResponse = [DeleteCommentsResponseWarning]?

--- a/Sources/T2ScholaCoreSwift/Request/DeleteCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/DeleteCommentsRequest.swift
@@ -7,7 +7,7 @@ struct DeleteCommentsRequest: RestAPIRequest {
     typealias RequestBody = Void
     typealias Response = DeleteCommentsResponse
     
-    let method: HTTPMethod = .get
+    let method: HTTPMethod = .post
     
     let queryParameters: [String: Any]?
     

--- a/Sources/T2ScholaCoreSwift/Request/DeleteCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/DeleteCommentsRequest.swift
@@ -25,7 +25,7 @@ struct DeleteCommentsRequest: RestAPIRequest {
     }
 }
 
-public struct DeleteCommentsRequestBody: UrlEncodedBody {
+public struct DeleteCommentsRequestBody: WwwFormUrlEncodedBody {
     public let query: [String : Any]
 }
 

--- a/Sources/T2ScholaCoreSwift/Request/DeleteCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/DeleteCommentsRequest.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct DeleteCommentsRequest: RestAPIRequest {
+    typealias RequestBody = Void
+    typealias Response = DeleteCommentsResponse
+    
+    let method: HTTPMethod = .get
+    
+    let queryParameters: [String: Any]?
+    
+    init(commentId: Int, wsToken: String) {
+        queryParameters = [
+            "moodlewsrestformat" : "json",
+            "wstoken" : wsToken,
+            "wsfunction" : "core_comment_delete_comments",
+            "comments[0]" : commentId //id of the comment (default: 0)
+        ]
+    }
+}
+
+public typealias DeleteCommentsResponse = [DeleteCommentsResponseWarning]?
+
+public struct DeleteCommentsResponseWarning: Codable {
+    public let item: String?
+    public let itemid: Int?
+    // The warning code can be used by the client app to implement specific behaviour.
+    public let warningcode: String
+    // Untranslated english message to explain the warning.
+    public let message: String
+}

--- a/Sources/T2ScholaCoreSwift/Request/Protocol/Request.swift
+++ b/Sources/T2ScholaCoreSwift/Request/Protocol/Request.swift
@@ -40,7 +40,7 @@ public protocol MultipartFormDataBody {
     var fileName: String { get }
 }
 
-public protocol UrlEncodedBody {
+public protocol WwwFormUrlEncodedBody {
     var query: [String: Any] { get }
 }
 
@@ -63,7 +63,7 @@ extension Request {
 
         if requestBody is Encodable {
             header["Content-Type"] = "application/json"
-        } else if requestBody is UrlEncodedBody {
+        } else if requestBody is WwwFormUrlEncodedBody {
             header["Content-Type"] = "application/x-www-form-urlencoded"
         } else if requestBody is MultipartFormDataBody {
             header["Content-Type"] = "multipart/form-data; boundary=\(boundary)"
@@ -78,7 +78,6 @@ extension Request {
 extension Request where Response: Decodable {
     public func decode(data: Data) throws -> Response {
         let decoder = JSONDecoder()
-        print(String(data: data, encoding: .utf8)!)
         decoder.dateDecodingStrategy = .secondsSince1970
         return try decoder.decode(Response.self, from: data)
     }
@@ -98,7 +97,7 @@ extension Request where RequestBody: Encodable {
     }
 }
 
-extension Request where RequestBody: UrlEncodedBody {
+extension Request where RequestBody: WwwFormUrlEncodedBody {
     public func encode(requestBody: RequestBody) throws -> Data {
         var allowedCharacterSet = CharacterSet.urlQueryAllowed
         allowedCharacterSet.remove(charactersIn: "!*'();:@&=+$,/?%#[]")

--- a/Sources/T2ScholaCoreSwift/Request/Protocol/Request.swift
+++ b/Sources/T2ScholaCoreSwift/Request/Protocol/Request.swift
@@ -72,6 +72,7 @@ extension Request {
 extension Request where Response: Decodable {
     public func decode(data: Data) throws -> Response {
         let decoder = JSONDecoder()
+        print(String(data: data, encoding: .utf8)!)
         decoder.dateDecodingStrategy = .secondsSince1970
         return try decoder.decode(Response.self, from: data)
     }

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -66,6 +66,10 @@ public struct T2Schola {
         try await apiClient.send(request: AddCommentsRequest(instanceId: instanceId, itemId: itemId, comment: comment, wsToken: wsToken))
     }
     
+    public func deleteComments(commentId: Int, wsToken: String) async throws -> DeleteCommentsResponse {
+        try await apiClient.send(request: DeleteCommentsRequest(commentId: commentId, wsToken: wsToken))
+    }
+
     public static func changeToMock() {
         changeToMockBaseHost()
     }

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -61,7 +61,11 @@ public struct T2Schola {
     public func getSubmissionComments(instanceId: Int, itemId: Int, wsToken: String) async throws -> SubmissionCommentsResponse {
         try await apiClient.send(request: SubmissionCommentsRequest(instanceId: instanceId, itemId: itemId, wsToken: wsToken))
     }
-
+    
+    public func addComments(instanceId: Int, itemId: Int, comment: String, wsToken: String) async throws -> AddCommentsResponse {
+        try await apiClient.send(request: AddCommentsRequest(instanceId: instanceId, itemId: itemId, comment: comment, wsToken: wsToken))
+    }
+    
     public static func changeToMock() {
         changeToMockBaseHost()
     }

--- a/Tests/T2ScholaCoreSwiftTests/T2ScholaTests.swift
+++ b/Tests/T2ScholaCoreSwiftTests/T2ScholaTests.swift
@@ -101,6 +101,37 @@ final class T2ScholaTests: XCTestCase {
             }
         }
     }
+    
+    func testAddCommentRequest() async throws {
+        let t2Schola = T2Schola(
+            apiClient: APIClientMock(
+                mockString:
+#"""
+[
+    {
+        "id": 12358,
+        "content": "<div class=\"no-overflow\"><div class=\"text_to_html\">test comment あ !*'();:@&amp;=+$,/?%#[]</div></div>",
+        "format": 0,
+        "timecreated": 1660098833,
+        "strftimeformat": "%Y年 %m月 %d日(%a) %H:%M",
+        "profileurl": "https://t2schola.titech.ac.jp/user/view.php?id=10000&amp;course=20000",
+        "fullname": "Fullname",
+        "time": "2022年 08月 10日(水) 11:33",
+        "avatar": "<a href=\"https://t2schola.titech.ac.jp/user/view.php?id=10000&amp;course=20000\" class=\"d-inline-block aabtn\"><img src=\"https://t2schola.titech.ac.jp/pluginfile.php/34988/user/icon/titech/f2?rev=1147621\" class=\"userpicture\" width=\"16\" height=\"16\" alt=\"test\" title=\"test\" /></a>",
+        "userid": 10000,
+        "delete": true
+    }
+]
+"""#
+                )
+            )
+        let response = try await t2Schola.addComments(instanceId: 80000, itemId: 500000, comment: "test comment あ !*'();:@&=+$,/?%#[]", wsToken: token)
+        XCTAssertEqual(response.count, 1)
+        XCTAssertEqual(response[0].id, 12358)
+        XCTAssertEqual(response[0].format, 0)
+        
+    }
+    
 
 //    func testGetNotifications() async throws {
 //        let t2Schola = T2Schola()


### PR DESCRIPTION
- `AddCommentsRequest`
    - 提出コメント(1個)を追加する
    - 引数
        - `wsToken`
        - `instanceId` : 課題のid
        - `itemId` : 提出課題のid (`lastattempt.submission.id`)
    - 戻り値 : commentの情報の配列
- `DeleteCommentsRequest`
    - 提出コメント(1個)を削除する
    - 引数
        - `wsToken`
        - `commentId` : `AddCommentsRequest`の戻り値のうち`id`
    - 戻り値 : `warning`が無ければ空の配列

いずれもT2SCHOLAで実際にコメント追加・削除の検証済み。またTitechApp内で一度に複数の提出コメントを追加・削除することはなさそうなので1コメントずつ操作するよう書いている。