### PR TITLE
gradingstatusの修正・命名の変更

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionCommentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionCommentsRequest.swift
@@ -3,9 +3,9 @@ import Foundation
 import FoundationNetworking
 #endif
 
-struct SubmissionCommentsRequest: RestAPIRequest {
+struct AssignmentSubmissionCommentsRequest: RestAPIRequest {
     typealias RequestBody = Void
-    typealias Response = SubmissionCommentsResponse
+    typealias Response = AssignmentSubmissionCommentsResponse
     
     let method: HTTPMethod = .get
     
@@ -25,16 +25,16 @@ struct SubmissionCommentsRequest: RestAPIRequest {
     }
 }
 
-public struct SubmissionCommentsResponse: Codable {
-    public let comments: [SubmissionCommentResponse] //List of comments
+public struct AssignmentSubmissionCommentsResponse: Codable {
+    public let comments: [AssignmentSubmissionCommentResponse] //List of comments
     public let count: Int?  //Total number of comments.
     public let perpage: Int?  //Number of comments per page.
     public let canpost: Bool?  //Whether the user can post in this comment area.
-    public let warnings: [SubmissionCommentsResponseWarning]?  //list of warnings
+    public let warnings: [AssignmentSubmissionCommentsResponseWarning]?  //list of warnings
 }
 
 
-public struct SubmissionCommentResponse: Codable {
+public struct AssignmentSubmissionCommentResponse: Codable {
     public let id: Int   //Comment ID
     public let content: String   //The content text formatted
     public let format: Int   //content format (1 = HTML, 0 = MOODLE, 2 = PLAIN or 4 = MARKDOWN)
@@ -48,7 +48,7 @@ public struct SubmissionCommentResponse: Codable {
     public let delete: Bool?  //Permission to delete=true/false
 }
 
-public struct SubmissionCommentsResponseWarning: Codable {
+public struct AssignmentSubmissionCommentsResponseWarning: Codable {
     public let item: String?
     public let itemid: Int?
     // The warning code can be used by the client app to implement specific behaviour.

--- a/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
@@ -152,6 +152,16 @@ public enum AssignmentSubmissionStatus: String, Codable {
     case noonlinesubmissions = "noonlinesubmissions"
     case nosubmission = "nosubmission"
     case gradedfollowupsubmit = "gradedfollowupsubmit"
+    case unknown = "unknown"
+
+    public init(from decoder: Decoder) throws {
+        let rawValue = try decoder.singleValueContainer().decode(String.self)
+        guard let status = AssignmentSubmissionStatus(rawValue: rawValue) else {
+            self = .unknown
+            return
+        }
+        self = status
+    }
 }
 
 public enum AssignmentGradingStatus: String, Codable {
@@ -162,4 +172,15 @@ public enum AssignmentGradingStatus: String, Codable {
     case gradedfollowupsubmit = "gradedfollowupsubmit"
     // found exception
     case notmarked = "notmarked"
+    case inmarking = "inmarking"
+    case unknown = "unknown"
+
+    public init(from decoder: Decoder) throws {
+        let rawValue = try decoder.singleValueContainer().decode(String.self)
+        guard let status = AssignmentGradingStatus(rawValue: rawValue) else {
+            self = .unknown
+            return
+        }
+        self = status
+    }
 }

--- a/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
@@ -74,7 +74,7 @@ public struct AssignmentSubmissionLastAttempt: Codable {
     public let cansubmit: Bool   // Whether the user can submit.
     public let extensionduedate: Date   // Extension due date.
     public let blindmarking: Bool   // Whether blind marking is enabled.
-    public let gradingstatus: AssignmentGradingStatus?  // Grading status.
+    public let gradingstatus: AssignmentGradingStatus   // Grading status.
     public let usergroups: [Int]   // User groups in the course.
 //    public let timelimit: Int?  // @since 4.0. Time limit for submission.
 }

--- a/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/AssignmentSubmissionStatusRequest.swift
@@ -74,7 +74,7 @@ public struct AssignmentSubmissionLastAttempt: Codable {
     public let cansubmit: Bool   // Whether the user can submit.
     public let extensionduedate: Date   // Extension due date.
     public let blindmarking: Bool   // Whether blind marking is enabled.
-    public let gradingstatus: AssignmentGradingStatus   // Grading status.
+    public let gradingstatus: AssignmentGradingStatus?  // Grading status.
     public let usergroups: [Int]   // User groups in the course.
 //    public let timelimit: Int?  // @since 4.0. Time limit for submission.
 }

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -58,8 +58,8 @@ public struct T2Schola {
         try await apiClient.send(request: NotificationReadRequest(notificationId: notificationId, wsToken: wsToken))
     }
     
-    public func getSubmissionComments(instanceId: Int, itemId: Int, wsToken: String) async throws -> SubmissionCommentsResponse {
-        try await apiClient.send(request: SubmissionCommentsRequest(instanceId: instanceId, itemId: itemId, wsToken: wsToken))
+    public func getSubmissionComments(instanceId: Int, itemId: Int, wsToken: String) async throws -> AssignmentSubmissionCommentsResponse {
+        try await apiClient.send(request: AssignmentSubmissionCommentsRequest(instanceId: instanceId, itemId: itemId, wsToken: wsToken))
     }
 
     public static func changeToMock() {


### PR DESCRIPTION
- `gradingstatus: AssignmentGradingStatus` の parse 時にエラーが出るということで取り急ぎ修正
- SubmissionCommentsResponse -> AssignmentSubmissionCommentsResponse