### PR TITLE
CourseContentModuleにinstanceを追加

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/CourseContentsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/CourseContentsRequest.swift
@@ -35,6 +35,7 @@ public struct CourseContentModule: Codable {
     public let modname: CourseContentModuleName
     public let url: URL?
     public let name: String
+    public let instance: Int
     public let description: String?
     public let modicon: URL
     public let modplural: String


### PR DESCRIPTION
AssignmentDetailsを表示するために必要なidが取得できる

instanceの定義は以下
https://github.com/moodle/moodle/blob/7c3188b2ca754a3842cb4b1e0a145163c1595f59/lib/modinfolib.php#L2136