### PR TITLE
フォーラムの投稿一覧取得に必要な、フォーラムのIDを取得する機能の作成

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/ForumsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/ForumsRequest.swift
@@ -1,0 +1,75 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct ForumsRequest: RestAPIRequest {
+    typealias RequestBody = Void
+    typealias Response = ForumsResponse
+    
+    let method: HTTPMethod = .get
+    
+    let queryParameters: [String: Any]?
+    
+    init(wsToken: String, courseId: Int?) {  //
+        if courseId != nil {
+            queryParameters = [
+                "moodlewsrestformat" : "json",
+                "wstoken" : wsToken,
+                "wsfunction" : "mod_forum_get_forums_by_courses",
+                "courseids[0]" : courseId!  // supports only one id
+            ]
+        } else {
+            queryParameters = [
+                "moodlewsrestformat" : "json",
+                "wstoken" : wsToken,
+                "wsfunction" : "mod_forum_get_forums_by_courses"
+                // returns all forum ids that user can check
+            ]
+        }
+    }
+}
+
+public typealias ForumsResponse = [ForumResponse]
+//public struct ForumsResponse: Codable {
+//    public let discussions: [ForumResponse]  // post
+//}
+
+public struct ForumResponse: Codable, Identifiable {
+    public let id: Int // Forum id. <- can use at ForumDiscussionRequest
+    public let course: Int // Course id.
+    public let type: String // The forum type.
+    public let name: String // Forum name.
+    public let intro: String // The forum intro.
+    public let introformat: Int // Intro format (1 = HTML, 0 = MOODLE, 2 = PLAIN or 4 = MARKDOWN).
+    public let introfiles: [CoreWSExternalFile]?
+    public let duedate: Bool? // Duedate for the user.
+    public let cutoffdate: Bool? // Cutoffdate for the user.
+    public let assessed: Int // Aggregate type.
+    public let assesstimestart: Date // Assess start time.
+    public let assesstimefinish: Date // Assess finish time.
+    public let scale: Int // Scale.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public let grade_forum: Int // Whole forum grade.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public let grade_forum_notify: Int // Whether to send notifications to students upon grading by default.
+    public let maxbytes: Int // Maximum attachment size.
+    public let maxattachments: Int // Maximum number of attachments.
+    public let forcesubscribe: Int // Force users to subscribe.
+    public let trackingtype: Int // Subscription mode.
+    public let rsstype: Int // RSS feed for this activity.
+    public let rssarticles: Int // Number of RSS recent articles.
+    public let timemodified: Date // Time modified.
+    public let warnafter: Int // Post threshold for warning.
+    public let blockafter: Int // Post threshold for blocking.
+    public let blockperiod: Int // Time period for blocking.
+    public let completiondiscussions: Int // Student must create discussions.
+    public let completionreplies: Int // Student must post replies.
+    public let completionposts: Int // Student must post discussions or replies.
+    public let cmid: Int // Course module id.
+    public let numdiscussions: Int? // Number of discussions in the forum.
+    public let cancreatediscussions: Bool? // If the user can create discussions.
+    public let lockdiscussionafter: Int? // After what period a discussion is locked.
+    public let istracked: Bool? // If the user is tracking the forum.
+    public let unreadpostscount: Int? // The number of unread posts for tracked forums.
+}

--- a/Sources/T2ScholaCoreSwift/Request/ForumsRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/ForumsRequest.swift
@@ -11,13 +11,13 @@ struct ForumsRequest: RestAPIRequest {
     
     let queryParameters: [String: Any]?
     
-    init(wsToken: String, courseId: Int?) {  //
-        if courseId != nil {
+    init(wsToken: String, courseId: Int?) {
+        if let courseId = courseId {
             queryParameters = [
                 "moodlewsrestformat" : "json",
                 "wstoken" : wsToken,
                 "wsfunction" : "mod_forum_get_forums_by_courses",
-                "courseids[0]" : courseId!  // supports only one id
+                "courseids[0]" : courseId  // supports only one id
             ]
         } else {
             queryParameters = [

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -78,6 +78,10 @@ public struct T2Schola {
         try await apiClient.send(request: ForumDiscussionsRequest(wsToken: wsToken, forumId: forumId))
     }
     
+    public func getForumByCourse(wsToken: String, courseId: Int?) async throws -> ForumsResponse {
+        try await apiClient.send(request: ForumsRequest(wsToken: wsToken, courseId: courseId))
+    }
+    
     public static func changeToMock() {
         changeToMockBaseHost()
     }

--- a/Tests/T2ScholaCoreSwiftTests/T2ScholaTests.swift
+++ b/Tests/T2ScholaCoreSwiftTests/T2ScholaTests.swift
@@ -547,7 +547,158 @@ final class T2ScholaTests: XCTestCase {
             print(error._domain)
             print(error._code)
             print(error)
-        }}
+        }
+    }
+    
+    func testForumWithCourseId() async throws {
+        let t2Schola = T2Schola(
+            apiClient: APIClientMock(
+                mockString:
+#"""
+[
+  {
+    "id": 22883,
+    "course": 21754,
+    "type": "news",
+    "name": "アナウンスメント",
+    "intro": "一般ニュースおよびアナウンスメント",
+    "introformat": 1,
+    "introfiles": [],
+    "duedate": 0,
+    "cutoffdate": 0,
+    "assessed": 0,
+    "assesstimestart": 0,
+    "assesstimefinish": 0,
+    "scale": 0,
+    "grade_forum": 0,
+    "grade_forum_notify": 0,
+    "maxbytes": 0,
+    "maxattachments": 1,
+    "forcesubscribe": 1,
+    "trackingtype": 1,
+    "rsstype": 0,
+    "rssarticles": 0,
+    "timemodified": 1646078016,
+    "warnafter": 0,
+    "blockafter": 0,
+    "blockperiod": 0,
+    "completiondiscussions": 0,
+    "completionreplies": 0,
+    "completionposts": 0,
+    "cmid": 62599,
+    "numdiscussions": 9,
+    "cancreatediscussions": false,
+    "lockdiscussionafter": 0,
+    "istracked": false
+  }
+]
+"""#
+            )
+        )
+        do {
+            let response = try await t2Schola.getForumByCourse(wsToken: token, courseId: 21754)
+            XCTAssertEqual(response.count, 1)
+            XCTAssertEqual(response[0].id, 22883)
+            XCTAssertEqual(response[0].course, 21754)
+        } catch {
+            print(error._domain)
+            print(error._code)
+            print(error)
+        }
+    }
+    
+    func testForumWithoutCourseId() async throws {
+        let t2Schola = T2Schola(
+            apiClient: APIClientMock(
+                mockString:
+#"""
+[
+  {
+    "id": 22883,
+    "course": 21754,
+    "type": "news",
+    "name": "アナウンスメント",
+    "intro": "一般ニュースおよびアナウンスメント",
+    "introformat": 1,
+    "introfiles": [],
+    "duedate": 0,
+    "cutoffdate": 0,
+    "assessed": 0,
+    "assesstimestart": 0,
+    "assesstimefinish": 0,
+    "scale": 0,
+    "grade_forum": 0,
+    "grade_forum_notify": 0,
+    "maxbytes": 0,
+    "maxattachments": 1,
+    "forcesubscribe": 1,
+    "trackingtype": 1,
+    "rsstype": 0,
+    "rssarticles": 0,
+    "timemodified": 1646078016,
+    "warnafter": 0,
+    "blockafter": 0,
+    "blockperiod": 0,
+    "completiondiscussions": 0,
+    "completionreplies": 0,
+    "completionposts": 0,
+    "cmid": 62599,
+    "numdiscussions": 9,
+    "cancreatediscussions": false,
+    "lockdiscussionafter": 0,
+    "istracked": false
+  },
+  {
+    "id": 15007,
+    "course": 14742,
+    "type": "news",
+    "name": "化学反応動力学(C)の講義について",
+    "intro": "化学反応動力学(C)を受講する皆さん\r\n<br>\r\n<br>2Qの化学反応動力学(C)の前半を担当する材料系無機材料フォーカスの松下伸広です。講義は6/11(金)より毎週の火金5-6限での開講です。 \r\n\r\n<br>コロナ禍によって皆さん方は一年次に来校して講義を受ける機会が殆どなかったことから、二年次は対面講義を増やして欲しいという希望が多いことや、とは言いながら感染を心配する方もいること等を考慮して、講義のあり方について、後半担当する生駒先生と無機材料フォーカス教育委員の保科先生と相談しました。この結果、以下の様にハイブリッド形式で行うことに致しました。\r\n \r\n\r\n<br>\r\n<br>化学反応動力学(C)　2Q 火金5-6限\r\n<br>担当教員：松下伸広(前半)、生駒俊之(後半)\r\n<br>講義室：教員は南7号館201講義室で講義を行う。早く講義に来た人から南7号館201講義室に一席おきに座ることにして、もし201講義室が一杯になった場合に、すぐ隣の202講義室にて一席おきに着席することにする。同講義の前半の内容は下記Zoomでも配信も行う。(後半については講義開始前に生駒先生より連絡があると思います。)\r\n \r\n\r\n<br>\r\n<br>トピック: 化学反応動力学(前半)_松下伸広 の Zoom ミーティング\r\n<br>時間: 2Q火金 5-6限\r\n<br>講義室：南7号館201(および202)講義室　下記Zoom URLでも聴講可能　\r\n<br>Zoomミーティングに参加する\r\n<br><a href=\"https://us06web.zoom.us/j/**************?pwd=***************************\">https://us06web.zoom.us/j/****************?pwd=*******************************************</a> \r\n\r\n<br>ミーティングID: 978 6222 7450\r\n<br>パスコード: *********************ナウンスメント",
+    "introformat": 1,
+    "introfiles": [],
+    "duedate": 0,
+    "cutoffdate": 0,
+    "assessed": 0,
+    "assesstimestart": 0,
+    "assesstimefinish": 0,
+    "scale": 0,
+    "grade_forum": 0,
+    "grade_forum_notify": 0,
+    "maxbytes": 0,
+    "maxattachments": 1,
+    "forcesubscribe": 1,
+    "trackingtype": 1,
+    "rsstype": 0,
+    "rssarticles": 0,
+    "timemodified": 1623218039,
+    "warnafter": 0,
+    "blockafter": 0,
+    "blockperiod": 0,
+    "completiondiscussions": 0,
+    "completionreplies": 0,
+    "completionposts": 0,
+    "cmid": 21408,
+    "numdiscussions": 0,
+    "cancreatediscussions": false,
+    "lockdiscussionafter": 0,
+    "istracked": false
+  }
+]
+"""#
+            )
+        )
+
+        do {
+            let response = try await t2Schola.getForumByCourse(wsToken: token, courseId: nil)
+            XCTAssertEqual(response.count, 2)
+            XCTAssertEqual(response[0].id, 22883)
+            XCTAssertEqual(response[1].id, 15007)
+        } catch {
+            print(error._domain)
+            print(error._code)
+            print(error)
+        }
+    }
 
 //    func testGetNotifications() async throws {
 //        let t2Schola = T2Schola()


### PR DESCRIPTION
#23 で作成したフォーラムの投稿(アナウンスメント)一覧の取得に必要な `forumId` を得る機能を追加しました。(`mod_forum_get_forums_by_courses` より)
- 引数
    - `wstoken`
    - `courseId` : 任意としています。`nil`を代入するとユーザが閲覧可能なフォーラムが全て返ってきます。元の関数では複数の科目にも対応しているのですが、ひとまず 1科目 or 全科目 での実装としています
- 戻り値
    - forum の情報の配列 : 特にその `id` がフォーラムの投稿一覧の取得に使えます。`cmid` は T2SCHOLAのWeb上でのフォーラムのURLです (t2schola.titech.ac.jp/mod/forum/view.php?id=$cmid)
    
テストも追加済みです