### PR TITLE
ログイン時のエラーの際のHTMLを戻り値に追加

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/LoginRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/LoginRequest.swift
@@ -7,7 +7,7 @@ import FoundationNetworking
 
 public enum T2ScholaLoginError: Error {
     case parseHtml
-    case parseUrlScheme
+    case parseUrlScheme(responseHTML: String)
     case parseToken
 }
 
@@ -44,7 +44,7 @@ struct LoginRequest: T2ScholaRequest {
             let decodedData = Data(base64Encoded: href.replacingOccurrences(of: "mmt2schola://token=", with: "")),
             let decodedStr = String(data: decodedData, encoding: .utf8)
         else {
-            throw T2ScholaLoginError.parseUrlScheme
+            throw T2ScholaLoginError.parseUrlScheme(responseHTML: doc.body?.text ?? "")
         }
 
         let splitedToken = decodedStr.components(separatedBy: ":::")


### PR DESCRIPTION
- `T2ScholaLoginError`のうち`parseUrlScheme`でエラーが起きた際に、エラーをthrowする時にHTMLも一緒に返せるようにしました
    - エラー時にアプリ内でレスポンスのHTMLをコピーできるようにすることを目的としています
    - タグ付け等はまだで今はアプリの方の作業中です