### PR TITLE
Requestプロトコル内のdecodeで、エラー時にresponseのURLも返すように変更

### DIFF
--- a/Sources/T2ScholaCoreSwift/APIClient.swift
+++ b/Sources/T2ScholaCoreSwift/APIClient.swift
@@ -55,7 +55,7 @@ struct APIClientImpl: APIClient {
             throw APIClientError.invalidStatusCode(httpResponse.statusCode)
         }
 
-        return try request.decode(data: data)
+        return try request.decode(data: data, responseUrl: httpResponse.url)
     }
 
     func fetchData(request: URLRequest) async throws -> (Data, URLResponse) {
@@ -111,23 +111,27 @@ class HTTPClientDelegate: URLProtocol, URLSessionTaskDelegate {
 struct APIClientMock: APIClient {
     private let mockData: [(Any.Type, Any)]
     private let mockString: String?
+    private let mockResponseUrl: URL?
     private let error: APIClientError?
 
     init(mockData: [(Any.Type, Any)]) {
         self.mockData = mockData
         self.mockString = nil
+        self.mockResponseUrl = nil
         self.error = nil
     }
 
-    init(mockString: String) {
+    init(mockString: String, mockResponseUrl: URL?) {
         self.mockData = []
         self.mockString = mockString
+        self.mockResponseUrl = mockResponseUrl
         self.error = nil
     }
 
     init(error: APIClientError) {
         self.mockData = []
         self.mockString = nil
+        self.mockResponseUrl = nil
         self.error = error
     }
 
@@ -137,7 +141,7 @@ struct APIClientMock: APIClient {
         }
 
         if let mockString = mockString {
-            return try request.decode(data: mockString.data(using: .utf8)!)
+            return try request.decode(data: mockString.data(using: .utf8)!, responseUrl: mockResponseUrl)
         }
 
         for (key, value) in self.mockData {

--- a/Sources/T2ScholaCoreSwift/Request/LoginRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/LoginRequest.swift
@@ -8,8 +8,8 @@ import FoundationNetworking
 public enum T2ScholaLoginError: Error, Equatable {
     case parseHtml
     case policy
-    case parseUrlScheme(responseHTML: String)
-    case parseToken(responseHTML: String)
+    case parseUrlScheme(responseHTML: String, responseUrl: URL?)
+    case parseToken(responseHTML: String, responseUrl: URL?)
 }
 
 struct LoginRequest: T2ScholaRequest {
@@ -25,7 +25,7 @@ struct LoginRequest: T2ScholaRequest {
         "User-Agent": "Mozilla/5.0 (iPad; CPU OS 13_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Mobile/15E148 Safari/604.1"
     ]
 
-    func decode(data: Data) throws -> LoginResponse {
+    func decode(data: Data, responseUrl: URL?) throws -> LoginResponse {
         guard
             let doc = { () -> HTMLDocument? in
                 do {
@@ -48,7 +48,7 @@ struct LoginRequest: T2ScholaRequest {
             let decodedData = Data(base64Encoded: href.replacingOccurrences(of: "mmt2schola://token=", with: "")),
             let decodedStr = String(data: decodedData, encoding: .utf8)
         else {
-            throw T2ScholaLoginError.parseUrlScheme(responseHTML: String(data: data, encoding: .utf8) ?? "")
+            throw T2ScholaLoginError.parseUrlScheme(responseHTML: String(data: data, encoding: .utf8) ?? "", responseUrl: responseUrl)
         }
 
         let splitedToken = decodedStr.components(separatedBy: ":::")
@@ -56,7 +56,7 @@ struct LoginRequest: T2ScholaRequest {
         if splitedToken.count > 2 {
             return LoginResponse(wsToken: splitedToken[1])
         } else {
-            throw T2ScholaLoginError.parseToken(responseHTML: String(data: data, encoding: .utf8) ?? "")
+            throw T2ScholaLoginError.parseToken(responseHTML: String(data: data, encoding: .utf8) ?? "", responseUrl: responseUrl)
         }
     }
 

--- a/Sources/T2ScholaCoreSwift/Request/Protocol/Request.swift
+++ b/Sources/T2ScholaCoreSwift/Request/Protocol/Request.swift
@@ -29,7 +29,7 @@ public protocol Request {
 
     func encode(requestBody: RequestBody) throws -> Data
 
-    func decode(data: Data) throws -> Response
+    func decode(data: Data, responseUrl: URL?) throws -> Response
 }
 
 public struct EmptyRequestBody: Encodable {}
@@ -77,7 +77,7 @@ extension Request {
 }
 
 extension Request where Response: Decodable {
-    public func decode(data: Data) throws -> Response {
+    public func decode(data: Data, responseUrl: URL?) throws -> Response {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         do {

--- a/Sources/T2ScholaCoreSwift/T2Schola.swift
+++ b/Sources/T2ScholaCoreSwift/T2Schola.swift
@@ -16,8 +16,8 @@ public struct T2Schola {
     }
 
     #if DEBUG
-    public init(mockHtml: String) {
-        self.apiClient = APIClientMock(mockString: mockHtml)
+    public init(mockHtml: String, mockResponseUrl: URL?) {
+        self.apiClient = APIClientMock(mockString: mockHtml, mockResponseUrl: mockResponseUrl)
     }
     #endif
 

--- a/Tests/T2ScholaCoreSwiftTests/T2ScholaTests.swift
+++ b/Tests/T2ScholaCoreSwiftTests/T2ScholaTests.swift
@@ -37,7 +37,7 @@ final class T2ScholaTests: XCTestCase {
     func testPolicyError() async {
         let policyErrorHtml = try! String(contentsOf: Bundle.module.url(forResource: "policy_error", withExtension: "html")!)
 
-        let t2Schola = T2Schola(apiClient: APIClientMock(mockString: policyErrorHtml))
+        let t2Schola = T2Schola(apiClient: APIClientMock(mockString: policyErrorHtml, mockResponseUrl: nil))
 
         do {
             _ = try await t2Schola.getToken()
@@ -81,7 +81,7 @@ final class T2ScholaTests: XCTestCase {
                       }
                     ]
 
-                    """
+                    """, mockResponseUrl: nil
             )
         )
 
@@ -155,7 +155,7 @@ final class T2ScholaTests: XCTestCase {
                         ]
                     }
 
-                    """#
+                    """#, mockResponseUrl: nil
             )
         )
         if userMockServer { T2Schola.changeToMock() }
@@ -277,7 +277,7 @@ final class T2ScholaTests: XCTestCase {
                       "warnings": []
                     }
 
-                    """#
+                    """#, mockResponseUrl: nil
             )
         )
         let status = try await t2ScholaForMockGetAssignmentSubmissionStatus.getAssignmentSubmissionStatus(assignmentId: assignments.courses[0].assignments[0].id, userId: userId, wsToken: token)
@@ -304,7 +304,7 @@ final class T2ScholaTests: XCTestCase {
                             "delete": true
                         }
                     ]
-                    """#
+                    """#, mockResponseUrl: nil
             )
         )
         let response = try await t2Schola.addComments(instanceId: 80000, itemId: 500000, comment: "test comment あ !*'();:@&=+$,/?%#[]", wsToken: token)
@@ -430,7 +430,7 @@ final class T2ScholaTests: XCTestCase {
                       ],
                       "warnings": []
                     }
-                    """#
+                    """#, mockResponseUrl: nil
             )
         )
 
@@ -501,7 +501,7 @@ final class T2ScholaTests: XCTestCase {
                         ],
                         "warnings": []
                     }
-                    """#
+                    """#, mockResponseUrl: nil
             )
         )
 
@@ -617,7 +617,7 @@ final class T2ScholaTests: XCTestCase {
                         }
                       ]
                     }
-                    """#
+                    """#, mockResponseUrl: nil
             )
         )
 
@@ -676,7 +676,7 @@ final class T2ScholaTests: XCTestCase {
                         "istracked": false
                       }
                     ]
-                    """#
+                    """#, mockResponseUrl: nil
             )
         )
         do {
@@ -768,7 +768,7 @@ final class T2ScholaTests: XCTestCase {
                         "istracked": false
                       }
                     ]
-                    """#
+                    """#, mockResponseUrl: nil
             )
         )
 
@@ -787,7 +787,7 @@ final class T2ScholaTests: XCTestCase {
     func testAPIPolicyError() async {
         let policyErrorHtml = try! String(contentsOf: Bundle.module.url(forResource: "api_policy_error", withExtension: "html")!)
 
-        let t2Schola = T2Schola(apiClient: APIClientMock(mockString: policyErrorHtml))
+        let t2Schola = T2Schola(apiClient: APIClientMock(mockString: policyErrorHtml, mockResponseUrl: nil))
 
         do {
             _ = try await t2Schola.getSiteInfo(wsToken: "")
@@ -804,14 +804,15 @@ final class T2ScholaTests: XCTestCase {
     func testParseErrorWhenReturnedPortalHome() async {
         let parseErrorHtml = try! String(contentsOf: Bundle.module.url(forResource: "portal_home", withExtension: "html")!)
 
-        let t2Schola = T2Schola(apiClient: APIClientMock(mockString: parseErrorHtml))
+        let t2Schola = T2Schola(apiClient: APIClientMock(mockString: parseErrorHtml, mockResponseUrl: URL(string: "https://portal.nap.gsic.titech.ac.jp/")))
 
         do {
             _ = try await t2Schola.getToken()
             XCTFail()
         } catch {
-            if case let T2ScholaLoginError.parseUrlScheme(responseHTML) = error {
+            if case let T2ScholaLoginError.parseUrlScheme(responseHTML, responseUrl) = error {
                 XCTAssertEqual(parseErrorHtml, responseHTML)
+                XCTAssertEqual(URL(string: "https://portal.nap.gsic.titech.ac.jp/"), responseUrl)
             } else {
                 XCTFail()
             }


### PR DESCRIPTION
**引数の変更を行いました**
- Request内でdecodeを行う際、エラーとなった時にリダイレクト先のURLも返せるよう、引数に`responseUrl: URL?`を追加しました
- それにより`T2ScholaLoginError.parseUrlScheme`や`.parseToken`を返す際にbaseURLも返せるようにしました
- テストが通るようにdecodeの部分のresponseUrlも追加しました