### PR TITLE
QuizResponseのvisibleプロパティをコメントアウト

### DIFF
--- a/Sources/T2ScholaCoreSwift/Request/QuizzesRequest.swift
+++ b/Sources/T2ScholaCoreSwift/Request/QuizzesRequest.swift
@@ -74,7 +74,8 @@ public struct QuizResponse: Codable {
     public let hasfeedback: Int?  //  Whether the quiz has any non-blank feedback text
     public let hasquestions: Int?  //  Whether the quiz has questions
     public let section: Int?  //  Course section id
-    public let visible: Int?  //  Module visibility
+    //  Bool | Int のどちらも入る可能性があり、使わないのでコメントアウト
+    //    public let visible: Bool?  //  Module visibility
     public let groupmode: Int?  //  Group mode
     public let groupingid: Int?  //  Grouping id
 

--- a/Tests/T2ScholaCoreSwiftTests/T2ScholaTests.swift
+++ b/Tests/T2ScholaCoreSwiftTests/T2ScholaTests.swift
@@ -444,6 +444,7 @@ final class T2ScholaTests: XCTestCase {
             print(error._domain)
             print(error._code)
             print(error)
+            XCTFail()
         }
     }
 


### PR DESCRIPTION
visibleにInt, Boolの値が入る可能性があり、現在は不要なのでコメントアウトしました。